### PR TITLE
Make it possible to configure api externally

### DIFF
--- a/packages/api/Dockerfile
+++ b/packages/api/Dockerfile
@@ -4,11 +4,11 @@
 FROM maven:3.6.0-jdk-11-slim AS build
 COPY src /home/api/src
 COPY pom.xml /home/api
-RUN mvn -f /home/api/pom.xml clean install
+RUN mvn -f /home/api/pom.xml clean package
 
 #
 # Package API
 #
 FROM openjdk:11-jre-slim
-COPY --from=build /home/api/target/*.jar api.jar
-ENTRYPOINT ["java","-jar","api.jar"]
+COPY --from=build /home/api/target/api.jar api.jar
+ENTRYPOINT ["java","-jar","api.jar", "--spring.config.location=classpath:/application.properties,/etc/osahft/api.properties"]

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -10,12 +10,14 @@
 ### Build
 
 - JAR: `mvn clean package`
-- Docker Image: `docker build . -t $IMAGE_TAG`
+- Docker Image: `docker build . -t ${IMAGE_TAG}`
 
 ### Run
 
-- JAR: `java -jar api.jar`
-- Docker Image: `docker run $IMAGE_TAG`
+-
+JAR: `java -jar api.jar --spring.config.location=classpath:/application.properties,${PATH_TO_API_PROPERTIES}/api.properties`
+- Docker
+  Image: `docker run ${IMAGE_TAG} --mount type=bind,source=${PATH_TO_API_PROPERTIES}/api.properties,target=/etc/osahft/api.properties`
 
 ## How to generate assertions for unit tests
 


### PR DESCRIPTION
Make it possible to configure api externally via providing an api.properties file that overrides defaults from application.properties.